### PR TITLE
Change order of imports to satisfy goimports tool

### DIFF
--- a/crawl/crawl_test.go
+++ b/crawl/crawl_test.go
@@ -2,12 +2,13 @@ package crawl
 
 import (
 	"fmt"
-	"github.com/michaeldorner/hamster/http"
-	"github.com/michaeldorner/hamster/store"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/michaeldorner/hamster/http"
+	"github.com/michaeldorner/hamster/store"
 )
 
 var feed Feed = func(configuration *Configuration, client *http.Client, repository *store.Repository) <-chan Item {

--- a/crawl/item_test.go
+++ b/crawl/item_test.go
@@ -1,8 +1,9 @@
 package crawl
 
 import (
-	"github.com/michaeldorner/hamster/http"
 	"testing"
+
+	"github.com/michaeldorner/hamster/http"
 )
 
 func TestFileName(t *testing.T) {


### PR DESCRIPTION
Change order of imports so that the `goimports` tool doesn't complain anymore.
If you want to ensure a consistent imports style you should use `goimports -d ./` instead of `gofmt -d ./` in the CI environment.