### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,9 @@ jobs:
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
         fi
-
+        
+    - name: Format Check
+      run: diff -u <(echo -n) <(gofmt -d ./)
+      
     - name: Test
       run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,5 +24,5 @@ jobs:
             dep ensure
         fi
 
-    - name: Build
-      run: go build -v .
+    - name: Test
+      run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...


### PR DESCRIPTION
In this PR a workflow file is added to use GitHub's CI environment to build and test the application.

Compared to the Travis-CI file, the last step of uploading code coverage reports to Codecov is missing. A dedicated GitHub Action already exist to do that (see [https://github.com/codecov/codecov-action](https://github.com/codecov/codecov-action)). 
It is not part of this PR because I don't wanted to create an account for that. 